### PR TITLE
Add proper contibutor mention on ports' pages 

### DIFF
--- a/src/components/PortDetails.astro
+++ b/src/components/PortDetails.astro
@@ -20,7 +20,7 @@ const { assets, platforms, contributors } = port.data;
         <li class="mb-4">
             <p class="flex items-center gap-1 flex-wrap">
                 <span class="flex items-center gap-2">
-                    <Icon name="material-symbols:stack"/>Platforms: 
+                    <Icon name="material-symbols:stack"/>Platforms:
                 </span>
                 { platforms.map((p) => <Chip value={p} variant="secondary" />)}
             </p>
@@ -42,7 +42,7 @@ const { assets, platforms, contributors } = port.data;
         <div class="mb-3">
             <p class="text-muted z-10 pb-3 font-semibold text-light-purple">Assets:</p>
             <ul class="text-muted-purple">
-                { 
+                {
                     assets.map((a) => <li><Chip value={a} href={`/ports/${a}`} /></li>)
                 }
             </ul>
@@ -54,11 +54,11 @@ const { assets, platforms, contributors } = port.data;
         <div>
             <p class="text-muted z-10 pb-3 font-semibold text-light-purple">Contributors:</p>
             <ul class="text-muted-purple">
-                { 
-                    contributors.map((c) => 
+                {
+                    contributors.map((c) =>
                         <li>
                             <a class="flex items-center gap-2 py-1" href={`https://github.com/${c}`}>
-                                <img class="inline h-full w-6 rounded-full" src="https://avatars.githubusercontent.com/u/749751?v=4" alt={`${c} user profile`}>
+                                <img class="inline h-full w-6 rounded-full" src={`https://github.com/${c}.png?size=200`} alt={`${c} user profile`}>
                                 {c}
                             </a>
                         </li>

--- a/src/content/port/discord.md
+++ b/src/content/port/discord.md
@@ -3,7 +3,12 @@ title: Discord
 images: ['/src/assets/images/ports/betterdiscord.png']
 platforms: ['linux', 'windows', 'mac']
 assets: ['wildberries.theme.css']
+contributors: ['LordWorm1996']
 ---
+## Info
+
+1. It works on Betterdiscord, Vencord and Vesktop, it should also work on other Discord clients.
+2. Special thanks to MrTipson on GitHub for the base.css https://github.com/MrTipson/DiscordCSS
 
 ## Installation
 
@@ -11,11 +16,6 @@ assets: ['wildberries.theme.css']
 2. Extract it
 3. Place it inside /path/to/BetterDiscord/themes
 4. Activate it by going to the Discord Settings menu and on BetterDiscord -> Themes, you should see the theme click the enable button
-
-## Info
-
-1. It works on Betterdiscord, Vencord and Vesktop, it should also work on other Discord clients.
-2. Special thanks to MrTipson on GitHub for the base.css https://github.com/MrTipson/DiscordCSS
 
 ## Troubleshoot
 

--- a/src/content/port/hyprland.md
+++ b/src/content/port/hyprland.md
@@ -2,6 +2,7 @@
 title: hyprland
 images: ['/src/assets/images/ports/hyprland.png']
 platforms: ['linux']
+contributors: ['LordWorm1996']
 ---
 
 ## Installation

--- a/src/content/port/hyprlock.md
+++ b/src/content/port/hyprlock.md
@@ -2,6 +2,7 @@
 title: hyprlock
 platforms: ['linux']
 images: ['/src/assets/images/ports/hyprlock.png']
+contributors: ['LordWorm1996']
 ---
 
 ## Installation

--- a/src/content/port/kitty.md
+++ b/src/content/port/kitty.md
@@ -3,6 +3,7 @@ title: kitty
 images: ['/src/assets/images/ports/kitty.png']
 platforms: ['linux']
 assets: ['kitty.conf']
+contributors: ['LordWorm1996']
 ---
 
 1. Download the kitty.conf file

--- a/src/content/port/obsidian.md
+++ b/src/content/port/obsidian.md
@@ -3,6 +3,7 @@ title: obsidian
 images: ['/src/assets/images/ports/obsidian.png']
 platforms: ['linux', 'windows', 'mac']
 assets: ['Wildberries.zip']
+contributors: ['LordWorm1996']
 ---
 
 ## Installation

--- a/src/content/port/swaync.md
+++ b/src/content/port/swaync.md
@@ -2,6 +2,7 @@
 title: swaync
 platforms: ['linux']
 images: ['/src/assets/images/ports/swaync2.png']
+contributors: ['LordWorm1996']
 ---
 
 1. Download the config.json from https://github.com/LordWorm1996/Wildberries-Ports/blob/main/Source/swaync/config.json and style.css from https://github.com/LordWorm1996/Wildberries-Ports/blob/main/Source/swaync/style.css

--- a/src/content/port/waybar.md
+++ b/src/content/port/waybar.md
@@ -2,6 +2,7 @@
 title: waybar
 platforms: ['linux']
 images: ['/src/assets/images/ports/waybar.png']
+contributors: ['LordWorm1996']
 ---
 
 1. Download the config from https://github.com/LordWorm1996/Wildberries-Ports/blob/main/Source/waybar/config and style.css from https://github.com/LordWorm1996/Wildberries-Ports/blob/main/Source/waybar/config

--- a/src/content/port/wezterm.md
+++ b/src/content/port/wezterm.md
@@ -3,6 +3,7 @@ title: wezterm
 images: ['/src/assets/images/ports/wezterm.png']
 platforms: ['linux', 'windows', 'mac', 'FreeBSD', 'NetBSD']
 assets: ['.wezterm.lua']
+contributors: ['LordWorm1996']
 ---
 
 1. Download the .wezterm.lua file from this page (Do NOT change the Name!!!)

--- a/src/content/port/wlogout.md
+++ b/src/content/port/wlogout.md
@@ -2,6 +2,7 @@
 title: wlogout
 platforms: ['linux']
 images: ['/src/assets/images/ports/wlogout.png']
+contributors: ['LordWorm1996']
 ---
 
 1. Download the contents of the folder on https://github.com/LordWorm1996/Wildberries-Ports/tree/main/Source/wlogout that include the pictures, layout and style.css

--- a/src/content/port/wofi.md
+++ b/src/content/port/wofi.md
@@ -2,6 +2,7 @@
 title: wofi
 platforms: ['linux']
 images: ['/src/assets/images/ports/wofi.png']
+contributors: ['LordWorm1996']
 ---
 
 1. Download the config from https://github.com/LordWorm1996/Wildberries-Ports/blob/main/Source/wofi/config and style.css from https://github.com/LordWorm1996/Wildberries-Ports/blob/main/Source/wofi/style.css

--- a/src/content/port/zed.md
+++ b/src/content/port/zed.md
@@ -3,6 +3,7 @@ title: zed
 images: ['/src/assets/images/ports/zed.png']
 platforms: ['linux', 'mac', 'windows']
 assets: ['wildberries.json']
+contributors: ['LordWorm1996']
 ---
 
 1. Download the wildberries.json on this page


### PR DESCRIPTION
Made sure to use the port details section to display a mention of contributor.

Also changed the order of information on discord instructions to contextualize the requirement of third party clients from the start. 